### PR TITLE
Fix invalid image indexing

### DIFF
--- a/src/utils/imageByIndex.ts
+++ b/src/utils/imageByIndex.ts
@@ -6,6 +6,6 @@ import image3 from "../../public/meta_spray_into_camera.webp";
 export const images: StaticImageData[] = [image1, image2, image3];
 
 const imageByIndex = (index: number): StaticImageData =>
-  images[index % images.toString().length];
+  images[index % images.length];
 
 export default imageByIndex;


### PR DESCRIPTION
## Summary
- fix modulus calculation in `imageByIndex`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_683f74225b20832d884bbbb9d8be87c0