### PR TITLE
Enhance footer quick links and add partnerships section

### DIFF
--- a/src/components/ContactOptions.tsx
+++ b/src/components/ContactOptions.tsx
@@ -6,7 +6,7 @@ type Props = {};
 
 const ContactOptions = (props: Props) => {
   return (
-    <section className="4k:px-[20vw] xl:px-0 mx-auto mb-16">
+    <section id="contact" className="4k:px-[20vw] xl:px-0 mx-auto mb-16">
       <div className="text-colorPrimary flex justify-center items-center flex-col pb-12 pt-16 lg:flex-col lg: text-center">
         <h4 className="text-2xl font-semibold text-colorSecondary">
           Beratungstermin vereinbaren

--- a/src/components/FooterComponent.tsx
+++ b/src/components/FooterComponent.tsx
@@ -33,9 +33,12 @@ const FooterComponent = (props: Props) => {
         <nav aria-label="Footer" className="basis-1/3 flex gap-4 flex-col">
           <h4 className="border-b-2 mb-4 pb-2 text-xl">Quick Links</h4>
           <ul className=" flex gap-2 flex-col">
-            <li>Über uns</li>
-            <li>Kontakt</li>
-            <li>Unser Service</li>
+            <li>
+              <Link href="/#about">Über uns</Link>
+            </li>
+            <li>
+              <Link href="/#contact">Kontakt</Link>
+            </li>
             <li>
               <Link href="/impressum">Impressum</Link>
             </li>
@@ -45,14 +48,20 @@ const FooterComponent = (props: Props) => {
           </ul>
         </nav>
         <div className="basis-1/3">
-          <h4 className="border-b-2 mb-4 pb-2 text-xl">Unser Service</h4>
+          <h4 className="border-b-2 mb-4 pb-2 text-xl">Partnerschaften</h4>
           <ul className=" flex gap-2 flex-col">
-            <li>Sanitäranlagen </li>
-            <li>Büro</li>
-            <li>Aussenbereich</li>
-            <li>Kleinreparaturen</li>
-            <li>Fenster </li>
-            <li>Events</li>
+            <li className="flex items-center gap-2">
+              <div className="w-12 h-12 bg-colorPrimary text-white flex items-center justify-center rounded-sm">
+                P1
+              </div>
+              <span>Partner 1</span>
+            </li>
+            <li className="flex items-center gap-2">
+              <div className="w-12 h-12 bg-colorPrimary text-white flex items-center justify-center rounded-sm">
+                P2
+              </div>
+              <span>Partner 2</span>
+            </li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- link footer quick links to actual sections
- remove services list from footer
- add placeholder partnership logos and names
- allow linking to the contact section
- use CSS placeholders instead of binary images for partners

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68402135a7f0832d9b35dfd4093d8786